### PR TITLE
5462 replaced deprecated function with UIGraphicsImageRenderer

### DIFF
--- a/Sources/Swift/Internal/SignatureDrawingModel.swift
+++ b/Sources/Swift/Internal/SignatureDrawingModel.swift
@@ -134,19 +134,19 @@ class SignatureDrawingModel: SignatureBezierProviderDelegate {
         }
         
         let imageFrame = CGRect(origin: CGPoint.zero, size: size)
-        UIGraphicsBeginImageContextWithOptions(imageFrame.size, false, 0)
-        imageA?.draw(in: imageFrame)
-        imageB?.draw(in: imageFrame)
+        let renderer = UIGraphicsImageRenderer(size: imageFrame.size)
         
-        if let path = bezierPath {
-            color.setStroke()
-            color.setFill()
-            path.stroke()
-            path.fill()
+        let result = renderer.image { context in
+            imageA?.draw(in: imageFrame)
+            imageB?.draw(in: imageFrame)
+            
+            if let path = bezierPath {
+                color.setStroke()
+                color.setFill()
+                path.stroke()
+                path.fill()
+            }
         }
-        
-        let result = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
         
         return result
     }


### PR DESCRIPTION
for this card https://myxplorinfo.atlassian.net/browse/PES-5462 in iOS 17 UIGraphicsBeginImageContextWithOptions is deprecated and needs to be replaced with UIGraphicsImageRenderer